### PR TITLE
Handle multidigit nested arrays

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,8 +6,16 @@ export const getNestedObject = (obj, dotSeparatedKeys) => {
     pathArr.forEach((key, idx, arr) => {
       if (typeof key === 'string' && key.includes('[')) {
         try {
-          arr.splice(idx + 1, 0, Number(/\[([^)]+)\]/.exec(key)[1]));
-          arr[idx] = key.slice(0, -3); // eslint-disable-line no-param-reassign
+          // extract the array index as string
+          const pos = /\[([^)]+)\]/.exec(key)[1];
+          // get the index string length (i.e. '21'.length === 2)
+          const posLen = pos.length;
+          arr.splice(idx + 1, 0, Number(pos));
+
+          // keep the key (array name) without the index comprehension:
+          // (i.e. key without [] (string of length 2)
+          // and the length of the index (posLen))
+          arr[idx] = key.slice(0, (-2 - posLen)); // eslint-disable-line no-param-reassign
         } catch (e) {
           // do nothing
         }

--- a/test/util.js
+++ b/test/util.js
@@ -31,17 +31,28 @@ describe('Nested Object/Keys Check', () => {
     let mockObj = {
       nestedArray: [
         { goodKey: 'hello one' },
-        { goodKey: 'hello two' }
+        { goodKey: 'hello two' },
+        { goodKey: 'hello three' },
+        { goodKey: 'hello four' },
+        { goodKey: 'hello five' },
+        { goodKey: 'hello six' },
+        { goodKey: 'hello seven' },
+        { goodKey: 'hello eight' },
+        { goodKey: 'hello nine' },
+        { goodKey: 'hello ten' },
+        { goodKey: 'hello eleven' },
       ]
     };
     assert(getNestedObject(mockObj, 'nestedArray[0].goodKey') === 'hello one');
     assert(getNestedObject(mockObj, 'nestedArray[1].goodKey') === 'hello two');
+    assert(getNestedObject(mockObj, 'nestedArray[10].goodKey') === 'hello eleven');
 
     mockObj = {
-      nestedArray: ['a', 'b']
+      nestedArray: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
     };
     assert(getNestedObject(mockObj, 'nestedArray[0]') === 'a');
     assert(getNestedObject(mockObj, 'nestedArray[1]') === 'b');
+    assert(getNestedObject(mockObj, 'nestedArray[10]') === 'k');
   });
 
   it('should return undefined when array element in path does not exist', () => {


### PR DESCRIPTION
currently, arrays with index comprehension longer than one digit would fail.
(i.e. "arrayName[12]")
this PR handles this and takes care of indexes with variable length