### PR TITLE
Add custom type validator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module "typy" {
 
 	export default function typy (input: any, objectPath?: string): Typy
+	export function setCustomTypes(typy: Typy, validators: any): void
 
 	class Typy {
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import Typy from './typy';
+import { setCustomTypes } from './util';
 
-const t = (input, objectPath) => new Typy().t(input, objectPath);
+const commonTypy = new Typy();
+const t = (input, objectPath) => commonTypy.t(input, objectPath);
+const setCustom = validator => setCustomTypes(commonTypy, validator);
 const { Number } = new Typy().Number;
 const { String } = new Typy().String;
 const { Boolean } = new Typy().Boolean;
@@ -15,5 +18,6 @@ module.exports = {
   Boolean,
   Function,
   Null,
-  Undefined
+  Undefined,
+  setCustomTypes: setCustom
 };

--- a/src/typy.js
+++ b/src/typy.js
@@ -153,6 +153,10 @@ class Typy {
     if (this.isFunction) return this.input;
     return /* istanbul ignore next */ () => {};
   }
+
+  custom(checker) {
+    return checker(this.input);
+  }
 }
 
 export default Typy;

--- a/src/util.js
+++ b/src/util.js
@@ -71,9 +71,26 @@ const convertSchemaAndGetMatch = (obj, schemaObject) => {
   return -1;
 };
 
+const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1);
+
+const propertyFormat = prop => `is${capitalize(prop)}`;
+
+const setCustomTypes = (typy, validators) => {
+  Object.keys(validators).forEach((property) => {
+    const newValidator = propertyFormat(property);
+    if (typeof typy[newValidator] === 'undefined') {
+      Object.defineProperty(typy, newValidator, { get: () => validators[property](typy.input) });
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`This property ${property} is already defined.`);
+    }
+  });
+};
+
 module.exports = {
   getNestedObject,
   buildSchema,
   getSchemaMatch,
-  convertSchemaAndGetMatch
+  convertSchemaAndGetMatch,
+  setCustomTypes
 };

--- a/test/util.js
+++ b/test/util.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { getNestedObject, convertSchemaAndGetMatch, buildSchema, getSchemaMatch } from '../src/util';
+import { getNestedObject, convertSchemaAndGetMatch, buildSchema, getSchemaMatch, setCustomTypes } from '../src/util';
 import Typy from '../src/typy';
 
 describe('Nested Object/Keys Check', () => {
@@ -255,5 +255,17 @@ describe('Objects and Schema check', () => {
     assert(convertSchemaAndGetMatch(obj, objSchema) !== -1);
     assert(typeof convertSchemaAndGetMatch(obj, objSchema) === 'object');
     assert(convertSchemaAndGetMatch(obj, weirdObjSchema) === -1);
+  });
+
+  it('should test if obj match custom validator', () => {
+    const car = { type: 'car', brand: 'renault' };
+    const typy = new Typy();
+
+    setCustomTypes(typy, {
+      car: carTesting => typeof carTesting.type !== 'undefined' && typeof carTesting.brand !== 'undefined',
+      email: emailStr => emailStr.indexOf('@') !== -1
+    });
+    assert(typy.t(car).isCar === true, 'Defined check didn\'t work :(');
+    assert(typy.t('str').isEmail === false);
   });
 });


### PR DESCRIPTION
I love this library.
I 'am just a bit frustrated with its limits.
Right now, `typy` is able to test common types but what about extend types:
- phone
- date format
- currency
- custom object format (see UT added)
- ...

By example, for the `phone`, a possiblity would be to add a [phone library](https://www.npmjs.com/package/phone) but you increase the size of the library and I don't beleive that this is a good idee.

I would like to here your thoughts about this, maybe it is just me that is willing to a _type checking_ library as _a set of validators with some types checking_

**This code provides you the ability to use a custom type checking of your own.**