### PR TITLE
Adding support for bracket syntax

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,25 +1,10 @@
 const getNestedObject = (obj, dotSeparatedKeys) => {
   if (arguments.length > 1 && typeof dotSeparatedKeys !== 'string') return undefined;
   if (typeof obj !== 'undefined' && typeof dotSeparatedKeys === 'string') {
-    const pathArr = dotSeparatedKeys.split('.');
-    pathArr.forEach((key, idx, arr) => {
-      if (typeof key === 'string' && key.includes('[')) {
-        try {
-          // extract the array index as string
-          const pos = /\[([^)]+)\]/.exec(key)[1];
-          // get the index string length (i.e. '21'.length === 2)
-          const posLen = pos.length;
-          arr.splice(idx + 1, 0, Number(pos));
+    // split on ".", "[", "]", "'", """ and filter out empty elements
+    const splitRegex = /[.\[\]'"]/g; // eslint-disable-line no-useless-escape
+    const pathArr = dotSeparatedKeys.split(splitRegex).filter(k => k !== '');
 
-          // keep the key (array name) without the index comprehension:
-          // (i.e. key without [] (string of length 2)
-          // and the length of the index (posLen))
-          arr[idx] = key.slice(0, (-2 - posLen)); // eslint-disable-line no-param-reassign
-        } catch (e) {
-          // do nothing
-        }
-      }
-    });
     // eslint-disable-next-line no-param-reassign, no-confusing-arrow
     obj = pathArr.reduce((o, key) => (o && o[key] !== 'undefined' ? o[key] : undefined), obj);
   }

--- a/test/util.js
+++ b/test/util.js
@@ -74,14 +74,11 @@ describe('Nested Object/Keys Check', () => {
       ]
     };
 
-    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0].goodKey') === 'deep hello');
-    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0][@id]') === 'unique');
-
-    assert(getNestedObject(mockObj, 'firstArray[0].goodKey') === 'hello one');
     assert(getNestedObject(mockObj, '["@id"]') === 'weird');
+    assert(getNestedObject(mockObj, 'firstArray[0].goodKey') === 'hello one');
     assert(getNestedObject(mockObj, 'firstArray[0]["@id"]') === 'identifier');
     assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0].goodKey') === 'deep hello');
-    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0]["@id"]') === 'unique');
+    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0][@id]') === 'unique');
     assert(getNestedObject(mockObj, 'firstArray[0].stackedArray[0][1]') === 'a2');
   });
 

--- a/test/util.js
+++ b/test/util.js
@@ -56,6 +56,35 @@ describe('Nested Object/Keys Check', () => {
     assert(getNestedObject(mockObj, 'nestedArray[10]') === 'k');
   });
 
+  it('should return deeply nested object when there are multiple array elements in path', () => {
+    const mockObj = {
+      '@id': 'weird',
+      firstArray: [
+        {
+          '@id': 'identifier',
+          goodKey: 'hello one',
+          secondArray: [
+            {
+              '@id': 'unique',
+              goodKey: 'deep hello'
+            }
+          ],
+          stackedArray: [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c']]
+        }
+      ]
+    };
+
+    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0].goodKey') === 'deep hello');
+    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0][@id]') === 'unique');
+
+    assert(getNestedObject(mockObj, 'firstArray[0].goodKey') === 'hello one');
+    assert(getNestedObject(mockObj, '["@id"]') === 'weird');
+    assert(getNestedObject(mockObj, 'firstArray[0]["@id"]') === 'identifier');
+    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0].goodKey') === 'deep hello');
+    assert(getNestedObject(mockObj, 'firstArray[0].secondArray[0]["@id"]') === 'unique');
+    assert(getNestedObject(mockObj, 'firstArray[0].stackedArray[0][1]') === 'a2');
+  });
+
   it('should return undefined when array element in path does not exist', () => {
     const mockObj = {
       nestedArray: [


### PR DESCRIPTION
This fixes the issues found in https://github.com/flexdinesh/typy/issues/14 without breaking any current support (at least nothing in unit tests).

This adds support for the following scenarios that were not working:
```
'["@id"]'
"['@id']"
'someArray[0][1]'
'someObject.firstArray[0].secondArray[0].goodElement'
'someObject.firstArray[0].secondArray[0].complexObject["@id"]'
```