### PR TITLE
Add safeArray.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ const myObj = t(deepObj, 'badKey.goodKey').safeObject; // => undefined
   - [safeNumber](#safenumber)
   - [safeBoolean](#safeboolean)
   - [safeFunction](#safefunction)
+  - [safeArray](#safearray)
   - [isValid (Schema Validation)](#isvalid-schema-validation)
   - [addCustomTypes (Custom Types)](#addcustomtypes-custom-types)
 
@@ -453,6 +454,32 @@ const func = t(helloFunc).safeFunction; // => helloFunc reference
 const func = t('I am a string').safeFunction; // => empty function () => {}
 const func = t(undefined).safeFunction; // => empty function () => {}
 const func = t(null).safeFunction; // => empty function () => {}
+```
+
+#### safeArray
+
+Safely returns the value from a nested object path or an empty array. If the path specified exists but is not an array, returns an array containing the value of the specified path.
+
+```js
+const deepObj = {
+  nestedKey: [
+    {
+      goodKey: ['hello'],
+      numberKey: 10,
+      superNestedKey: {}
+    },
+  ]
+};
+// Typy can safely return the value from a nested key in an object or an array
+const myObj = t(deepObj, 'nestedKey').safeArray; // => [ { goodKey: ['hello'], numberKey: 10, superNestedKey: {} } ]
+const myObj = t(deepObj, 'nestedKey[0].goodKey').safeArray; // => ['hello']
+// Typy can wrap a value or object inside an array
+const myObj = t(deepObj, 'nestedKey[0].numberKey').safeArray; // => [ 10 ]
+const myObj = t(deepObj, 'nestedKey[0].superNestedKey').safeArray; // => [ {} ]
+// Typy won't throw if the key at any level is not found
+// instead will return an empty array
+const myObj = t(deepObj, 'nestedKey[1]').safeArray; // => []
+const myObj = t(deepObj, 'badKey.goodKey').safeArray; // => []
 ```
 
 #### isValid (Schema Validation)

--- a/src/typy.js
+++ b/src/typy.js
@@ -159,6 +159,12 @@ class Typy {
     if (this.isFunction) return this.input;
     return /* istanbul ignore next */ () => {};
   }
+
+  get safeArray() {
+    if (this.isArray) return this.input;
+    if (!this.isNullOrUndefined) return [this.input];
+    return [];
+  }
 }
 
 export default Typy;

--- a/test/typy.test.js
+++ b/test/typy.test.js
@@ -327,6 +327,51 @@ describe('Typy', () => {
     });
   });
 
+  describe('Safe Array', () => {
+    const deepObj = {
+      nestedKey: [
+        {
+          goodKey: ['hello'],
+          numberKey: 10,
+          objKey: {
+            data: 'irrelevant',
+          },
+          funcKey: () => {}
+        }
+      ],
+      nullKey: null,
+    };
+
+    test('should return the nested array in path', () => {
+      expect(t(deepObj.nestedKey).safeArray).toEqual(deepObj.nestedKey);
+      expect(t(deepObj, 'nestedKey').safeArray).toEqual(deepObj.nestedKey);
+      expect(t(deepObj.nestedKey[0].goodKey).safeArray).toEqual(deepObj.nestedKey[0].goodKey);
+      expect(t(deepObj, 'nestedKey[0].goodKey').safeArray).toEqual(deepObj.nestedKey[0].goodKey);
+    });
+
+    test('should return an array with a single value if path not an array', () => {
+      expect(t(deepObj.nestedKey[0].numberKey).isNumber);
+      expect(t(deepObj.nestedKey[0].numberKey).safeArray).toEqual([deepObj.nestedKey[0].numberKey]);
+      expect(t(deepObj, 'nestedKey[0].numberKey').safeArray).toEqual([deepObj.nestedKey[0].numberKey]);
+
+      expect(t(deepObj.nestedKey[0].objKey).isObject);
+      expect(t(deepObj.nestedKey[0].objKey).safeArray).toEqual([deepObj.nestedKey[0].objKey]);
+      expect(t(deepObj, 'nestedKey[0].objKey').safeArray).toEqual([deepObj.nestedKey[0].objKey]);
+
+      expect(t(deepObj.nestedKey[0].funcKey).isFunction);
+      expect(t(deepObj.nestedKey[0].funcKey).safeArray).toEqual([deepObj.nestedKey[0].funcKey]);
+      expect(t(deepObj, 'nestedKey[0].funcKey').safeArray).toEqual([deepObj.nestedKey[0].funcKey]);
+    });
+
+    test('should not throw if path not found', () => {
+      expect(t(deepObj, 'nestedKey[0].undefinedKey').safeArray).toEqual([]);
+      expect(t(deepObj, 'nestedKey[1]').safeArray).toEqual([]);
+
+      expect(t(deepObj, 'nullKey').isNull).toEqual(true);
+      expect(t(deepObj, 'nullKey').safeArray).toEqual([]);
+    });
+  });
+
   describe('New Instance', () => {
     test('should return new instance for each input', () => {
       const stringType = t('hello');


### PR DESCRIPTION
Useful when you hate undefined and you just want an empty array. :)

Anything other than null or undefined gets wrapped in an array and returned that way. It makes sense to me that if I'm calling .safeArray, I expect it to always return an array AND I don't want to lose the value of the path just because it happens to be a different type initially.