### PR TITLE
Add index.d.ts and src to whitelisted files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "files": [
     "lib",
+    "src",
+    "index.d.ts",
     "LICENSE"
   ],
   "repository": {


### PR DESCRIPTION
This is also related to #24. The typings didn't work since index.d.ts was not included in the npm package.